### PR TITLE
fix: use users timezone for display

### DIFF
--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -79,7 +79,7 @@ class ActivityResource extends Resource
                             ->label('Logged At')
                             ->content(
                                 fn (?Model $record): string => $record?->created_at
-                                    ? "{$record?->created_at->format('d/m/Y H:i')}"
+                                    ? "{$record?->created_at->setTimezone(DateTimePicker::make('fake')->getTimezone())->format('d/m/Y H:i')}"
                                     : '-'
                             ),
                     ])


### PR DESCRIPTION
Filament recently introduced the abilility for tables and forms to show dates / times in the users timezone, 
this patch updates the date on the view to do that aswell