### PR TITLE
Adds localization improvements to the table filters.

### DIFF
--- a/resources/lang/en/filament-logger.php
+++ b/resources/lang/en/filament-logger.php
@@ -25,7 +25,7 @@ return [
     'resource.label.new' => 'New',
     'resource.label.old_value' => 'Old Value',
     'resource.label.new_value' => 'New Value',
-    'resource.label.hint' => 'Can be key or value',
+    'resource.label.properties_hint' => 'Can be key or value',
     'resource.label.old_attributes' => 'Old Attribute or Value: ',
     'resource.label.new_attributes' => 'New Attribute or Value: ',
 ];

--- a/resources/lang/en/filament-logger.php
+++ b/resources/lang/en/filament-logger.php
@@ -25,4 +25,5 @@ return [
     'resource.label.new' => 'New',
     'resource.label.old_value' => 'Old Value',
     'resource.label.new_value' => 'New Value',
+    'resource.label.hint' => 'Can be key or value',
 ];

--- a/resources/lang/en/filament-logger.php
+++ b/resources/lang/en/filament-logger.php
@@ -26,4 +26,6 @@ return [
     'resource.label.old_value' => 'Old Value',
     'resource.label.new_value' => 'New Value',
     'resource.label.hint' => 'Can be key or value',
+    'resource.label.old_attributes' => 'Old Attribute or Value: ',
+    'resource.label.new_attributes' => 'New Attribute or Value: ',
 ];

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -175,7 +175,7 @@ class ActivityResource extends Resource
 					})
 					->form([
 						TextInput::make('old')
-                            ->label(__('filament-logger::filament-logger.resource.label.old_value'))
+                            ->label(__('filament-logger::filament-logger.resource.label.old'))
                             ->hint('Can be key or value'),
 					])
 					->query(function (Builder $query, array $data): Builder {
@@ -196,7 +196,7 @@ class ActivityResource extends Resource
 					})
 					->form([
 						TextInput::make('new')
-                            ->label(__('filament-logger::filament-logger.resource.label.new_value'))
+                            ->label(__('filament-logger::filament-logger.resource.label.new'))
                             ->hint('Can be key or value'),
 					])
 					->query(function (Builder $query, array $data): Builder {

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -176,7 +176,7 @@ class ActivityResource extends Resource
 					->form([
 						TextInput::make('old')
                             ->label(__('filament-logger::filament-logger.resource.label.old'))
-                            ->hint(__('filament-logger::filament-logger.resource.label.hint')),
+                            ->hint(__('filament-logger::filament-logger.resource.label.properties_hint')),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['old']) {
@@ -197,7 +197,7 @@ class ActivityResource extends Resource
 					->form([
 						TextInput::make('new')
                             ->label(__('filament-logger::filament-logger.resource.label.new'))
-                            ->hint(__('filament-logger::filament-logger.resource.label.hint')),
+                            ->hint(__('filament-logger::filament-logger.resource.label.properties_hint')),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['new']) {

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -166,7 +166,6 @@ class ActivityResource extends Resource
                     ->options(static::getSubjectTypeList()),
 
                 Filter::make('properties->old')
-					->label(__('filament-logger::filament-logger.resource.label.old_value'))
 					->indicateUsing(function (array $data): ?string {
 						if (!$data['old']) {
 							return null;
@@ -175,7 +174,9 @@ class ActivityResource extends Resource
 						return 'Old Attribute or Value: ' . $data['old'];
 					})
 					->form([
-						TextInput::make('old')->hint('Can be key or value'),
+						TextInput::make('old')
+                            ->label(__('filament-logger::filament-logger.resource.label.old_value'))
+                            ->hint('Can be key or value'),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['old']) {
@@ -186,7 +187,6 @@ class ActivityResource extends Resource
 					}),
 
 				Filter::make('properties->attributes')
-					->label(__('filament-logger::filament-logger.resource.label.new_value'))
 					->indicateUsing(function (array $data): ?string {
 						if (!$data['new']) {
 							return null;
@@ -195,7 +195,9 @@ class ActivityResource extends Resource
 						return 'New Attribute or Value: ' . $data['new'];
 					})
 					->form([
-						TextInput::make('new')->hint('Can be key or value'),
+						TextInput::make('new')
+                            ->label(__('filament-logger::filament-logger.resource.label.new_value'))
+                            ->hint('Can be key or value'),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['new']) {

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -171,7 +171,7 @@ class ActivityResource extends Resource
 							return null;
 						}
 
-						return 'Old Attribute or Value: ' . $data['old'];
+						return __('filament-logger::filament-logger.resource.label.old_attributes') . $data['old'];
 					})
 					->form([
 						TextInput::make('old')
@@ -192,7 +192,7 @@ class ActivityResource extends Resource
 							return null;
 						}
 
-						return 'New Attribute or Value: ' . $data['new'];
+						return __('filament-logger::filament-logger.resource.label.new_attributes') . $data['new'];
 					})
 					->form([
 						TextInput::make('new')

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -176,7 +176,7 @@ class ActivityResource extends Resource
 					->form([
 						TextInput::make('old')
                             ->label(__('filament-logger::filament-logger.resource.label.old'))
-                            ->hint('Can be key or value'),
+                            ->hint(__('filament-logger::filament-logger.resource.label.hint')),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['old']) {
@@ -197,7 +197,7 @@ class ActivityResource extends Resource
 					->form([
 						TextInput::make('new')
                             ->label(__('filament-logger::filament-logger.resource.label.new'))
-                            ->hint('Can be key or value'),
+                            ->hint(__('filament-logger::filament-logger.resource.label.hint')),
 					])
 					->query(function (Builder $query, array $data): Builder {
 						if (!$data['new']) {


### PR DESCRIPTION
New translation keys have been added that need to be added to all locals later on.
Feel free to change the translation keys.

- 1c86f49da3354a07f10c5eb67b4606b0ef0425d6 fixes the #41.
- df9b4e152e77c687e08f8a67498485722352a9fb updates the filter labels.
It is meant to be "key or value", not just the value.
- c9f8ab91c2957bc696672045fdae0dd0258a7e2f adds a new translation key for the localization of hints.
- 2fe31ad724b475c4fda7ea58adaeda76e8d4f117 adds new translation keys for the localization of filter indicators.