### PR TITLE
Fix language typo

### DIFF
--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -77,7 +77,7 @@ class ActivityResource extends Resource
                             ->label(__('filament-logger::filament-logger.resource.label.event')),
 
                         Placeholder::make('created_at')
-                            ->label(__('filament-logger::filament-logger.resource.label.event'))
+                            ->label(__('filament-logger::filament-logger.resource.label.logged_at'))
                             ->content(function (?Model $record): string {
                                 /** @var Activity&ActivityModel $record */
                                 return $record->created_at ? "{$record->created_at->format(config('filament-logger.datetime_format', 'd/m/Y H:i:s'))}" : '-';


### PR DESCRIPTION
This PR fix language typo, it should reference `logged_at` for created at table, not `event`.

Feel free to drop or accept this PR, thank you.