### PR TITLE
feat: control over the ActivityResourse if scoped to tenant or not

### DIFF
--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -10,6 +10,7 @@ return [
         'log_name' => 'Resource',
         'logger' => \Z3d0X\FilamentLogger\Loggers\ResourceLogger::class,
         'color' => 'success',
+		'scoped_to_tenant' => true,
         'exclude' => [
             //App\Filament\Resources\UserResource::class,
         ],

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -331,4 +331,10 @@ class ActivityResource extends Resource
     {
         return __('filament-logger::filament-logger.nav.log.icon');
     }
+
+	public static function isScopedToTenant(): bool
+    {
+		return config('filament-logger.resources.scoped_to_tenant', true);
+    }
+	
 }


### PR DESCRIPTION
This commit adds a new configuration option `scoped_to_tenant` to the `filament-logger.php` file. The option is set to `true` (default in Filament). And a isScopedToTenant public static function in ActivityResource.

Helpful in case the panel has multi tenancy active.