### PR TITLE
Update ActivityResource.php

### DIFF
--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -325,7 +325,7 @@ class ActivityResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return __(config('filament-logger.resources.navigation_group','Settings'));
+        return __('filament-logger::filament-logger.nav.group');
     }
 
     public static function getNavigationLabel(): string


### PR DESCRIPTION
Made the navigation group label translatable by calling its value from the translation files instead of making it as a config parameter because then it will not be easy to translate directly.