### PR TITLE
Update AbstractModelLogger.php

### DIFF
--- a/src/Loggers/AbstractModelLogger.php
+++ b/src/Loggers/AbstractModelLogger.php
@@ -29,7 +29,7 @@ abstract class AbstractModelLogger
     }
 
 
-    protected function activityLogger(string $logName = null): ActivityLogger
+    protected function activityLogger(?string $logName = null): ActivityLogger
     {
         $defaultLogName = $this->getLogName();
 


### PR DESCRIPTION
PHP Deprecated: Z3d0X\FilamentLogger\Loggers\AbstractModelLogger::activityLogger(): Implicitly marking parameter $logName as nullable is deprecated, the explicit nullable type must be used instead