### PR TITLE
Use translation key instead of config for navigation group

### DIFF
--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -328,6 +328,11 @@ class ActivityResource extends Resource
         return __(config('filament-logger.resources.navigation_group','Settings'));
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return __('filament-logger::filament-logger.nav.group');
+    }
+
     public static function getNavigationLabel(): string
     {
         return __('filament-logger::filament-logger.nav.log.label');


### PR DESCRIPTION
feat: replace config-based navigation group with translation key

- Use __('filament-logger::filament-logger.nav.group') instead of config lookup
- Improves multi-language support following Laravel conventions
- Maintains backward compatibility with existing translations